### PR TITLE
docs: fix x402 protocol broken links

### DIFF
--- a/src/content/en/x402-protocol/index.mdx
+++ b/src/content/en/x402-protocol/index.mdx
@@ -217,9 +217,9 @@ x402 works on multiple blockchain networks:
 
 Ready to integrate x402 payments?
 
-1. **[Installation →](/getting-started/installation)** - Set up the x402 SDK
-2. **[First Payment →](/getting-started/first-payment)** - Make your first x402 payment
-3. **[Integration Patterns →](/x402-protocol/integration-patterns)** - Common implementation patterns
+1. **[Installation](/getting-started/installation)** - Set up the x402 SDK
+2. **[xpay Facilitator](/x402-protocol/facilitator)** - Verify and settle x402 payments on Base
+3. **[Production Deployment](/getting-started/production-deployment)** - Configure production-ready deployments
 
 ## Resources
 
@@ -230,4 +230,4 @@ Ready to integrate x402 payments?
 
 ---
 
-Continue reading: [x402 Fundamentals →](/x402-protocol/fundamentals)
+Continue reading: [xpay Facilitator](/x402-protocol/facilitator)


### PR DESCRIPTION
## Summary
- Replace the broken `x402 Fundamentals` CTA with the existing xpay Facilitator page.
- Replace adjacent dead links to `First Payment` and `Integration Patterns` with existing docs pages.
- Remove the arrow glyphs from the three quick-start link labels so the section stays plain and consistent.

Fixes #3.

## Verification
- `npm run build`
- Live checks before the patch confirmed `/en/x402-protocol/fundamentals`, `/en/x402-protocol/integration-patterns`, and `/en/getting-started/first-payment` currently return 404.
- Live checks confirmed `/en/x402-protocol/facilitator`, `/en/getting-started/installation`, and `/en/getting-started/production-deployment` are valid docs pages.